### PR TITLE
Add GitHub workflow for macos build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew update
-        brew install cmake ninja gcc@12 llvm@15 postgresql@15
+        brew install cmake ninja gcc@12 llvm@15 postgresql@15 doxygen graphviz
         brew link postgresql@15 --force
 
     - name: Install Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, github-workflow]
   pull_request:
     branches: [ main ]
 
@@ -10,7 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest]
         compiler: [gcc, clang]
         exclude:
           - os: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,18 +17,18 @@ jobs:
           - os: windows-latest
             compiler: clang
         include:
-          - os: windows-latest
-            compiler: msvc
-            generator: "Visual Studio 17 2022"
-            arch: x64
-          - os: ubuntu-latest
-            compiler: gcc
-            generator: "Unix Makefiles"
-            arch: x64
-          - os: ubuntu-latest
-            compiler: clang
-            generator: "Unix Makefiles"
-            arch: x64
+          # - os: windows-latest
+          #   compiler: msvc
+          #   generator: "Visual Studio 17 2022"
+          #   arch: x64
+          # - os: ubuntu-latest
+          #   compiler: gcc
+          #   generator: "Unix Makefiles"
+          #   arch: x64
+          # - os: ubuntu-latest
+          #   compiler: clang
+          #   generator: "Unix Makefiles"
+          #   arch: x64
           - os: macos-latest
             compiler: gcc
             generator: "Unix Makefiles"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pentaledger
 
-![Build workflow]https://github.com/PentaLedger/pentaledger/actions/workflows/build.yml/badge.svg
+![Build workflow](https://github.com/PentaLedger/pentaledger/actions/workflows/build.yml/badge.svg)
 
 > [!IMPORTANT]  
 > This software is not ready for end-user usage, yet. Check back in the future. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pentaledger
 
+![Build workflow]https://github.com/PentaLedger/pentaledger/actions/workflows/build.yml/badge.svg
+
 > [!IMPORTANT]  
 > This software is not ready for end-user usage, yet. Check back in the future. 
 


### PR DESCRIPTION
- Added and fixed workflow for building on MacOS (clang and gcc) with unit tests.  If any of the unit tests fail, the build will fail.
- Added badge in readme to reflect last build status.